### PR TITLE
Added lcov report path for typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8147,6 +8147,11 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
       "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg=="
     },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+    },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -21802,6 +21807,14 @@
       "integrity": "sha512-9fNE0fm9zNDx1+b6hgy8rgDN2WsQLRiIrn3+fbqm0tazBVF6jiaCFAITxmU+WSFWYE03Xhp1joCircXOe1WVAQ==",
       "requires": {
         "tsutils": "^3.9.1"
+      }
+    },
+    "tslint-sonarts": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslint-sonarts/-/tslint-sonarts-1.9.0.tgz",
+      "integrity": "sha512-CJWt+IiYI8qggb2O/JPkS6CkC5DY1IcqRsm9EHJ+AxoWK70lvtP7jguochyNDMP2vIz/giGdWCfEM39x/I/Vnw==",
+      "requires": {
+        "immutable": "^3.8.2"
       }
     },
     "tsutils": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "tether": "^1.4.4",
     "tslint": "^5.19.0",
     "tslint-config-prettier": "^1.18.0",
-    "tslint-react": "^4.0.0"
+    "tslint-react": "^4.0.0",
+    "tslint-sonarts": "^1.9.0"
   },
   "devDependencies": {
     "@types/aws-sdk": "^2.7.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,4 @@
 sonar.projectKey=sms-staging-management-system_user-interface
 sonar.typescript.tslint.reportPaths=tslint-report.json
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+sonar.typescript.lcov.reportPaths=./coverage/lcov.info

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier"],
+  "extends": ["tslint:recommended", "tslint-react", "tslint-config-prettier", "tslint-sonarts"],
   "linterOptions": {
     "exclude": [
       "config/**/*.js",


### PR DESCRIPTION
Added sonar configuration for properly picking up testing coverage reports for TypeScript.